### PR TITLE
add observation-based preference learning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.4] - 2026-03-31
+
+### Added
+- `PreferenceProfile.update_from_observation(owner_id:, signals:)`: accumulates interaction signals (channel, direct_address, content_type) per owner and infers preferences after 20 observations — CLI-heavy usage → `:concise` verbosity, high direct_address ratio → `:conversational` tone, mixed channels → `:adaptive` format (8 specs)
+- `PreferenceProfile.observation_counts`: read accessor for accumulated observation count per owner
+- `PreferenceProfile.inferred_preferences(owner_id)`: read accessor for inferred preference list per owner
+- `PreferenceProfile.clear_observations`: test/reset helper to flush observation state
+
 ## [0.4.3] - 2026-03-30
 
 ### Added

--- a/lib/legion/extensions/mesh/helpers/preference_profile.rb
+++ b/lib/legion/extensions/mesh/helpers/preference_profile.rb
@@ -246,6 +246,86 @@ module Legion
           def personality_available?
             defined?(Legion::Extensions::Agentic::Self::Personality::Runners::Personality)
           end
+
+          OBSERVATION_THRESHOLD = 20
+
+          def update_from_observation(owner_id:, signals:)
+            @observation_counts  ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @observation_signals ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+
+            key = owner_id.to_s
+            @observation_counts[key] = (@observation_counts[key] || 0) + 1 # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @observation_signals[key] ||= [] # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @observation_signals[key] << signals # rubocop:disable ThreadSafety/ClassInstanceVariable
+
+            derive_and_store_observations(owner_id: key) if @observation_counts[key] >= OBSERVATION_THRESHOLD # rubocop:disable ThreadSafety/ClassInstanceVariable
+
+            { updated: true }
+          rescue StandardError => _e
+            { updated: false }
+          end
+
+          def observation_counts
+            @observation_counts ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+          end
+
+          def inferred_preferences(owner_id)
+            @inferred_preferences ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @inferred_preferences[owner_id.to_s] || [] # rubocop:disable ThreadSafety/ClassInstanceVariable
+          end
+
+          def clear_observations
+            @observation_counts    = {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @observation_signals   = {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @inferred_preferences  = {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+          end
+
+          def derive_and_store_observations(owner_id:)
+            @observation_signals ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            signals = @observation_signals[owner_id] || [] # rubocop:disable ThreadSafety/ClassInstanceVariable
+            return if signals.empty?
+
+            inferred = []
+            inferred << derive_verbosity(signals)
+            inferred << derive_tone(signals)
+            inferred << derive_format(signals)
+            inferred = inferred.compact
+
+            @inferred_preferences ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
+            @inferred_preferences[owner_id] = inferred # rubocop:disable ThreadSafety/ClassInstanceVariable
+
+            inferred.each do |pref|
+              store_preference(
+                owner_id: owner_id,
+                domain:   pref[:domain],
+                value:    pref[:value],
+                source:   pref[:source]
+              )
+            end
+          end
+
+          def derive_verbosity(signals)
+            cli_count = signals.count { |s| s[:channel] == :cli }
+            cli_ratio = cli_count.to_f / signals.size
+            return nil unless cli_ratio >= 0.5
+
+            { domain: 'verbosity', value: 'concise', source: 'observation', confidence: 0.65 }
+          end
+
+          def derive_tone(signals)
+            da_count = signals.count { |s| s[:direct_address] }
+            da_ratio = da_count.to_f / signals.size
+            return nil unless da_ratio >= 0.5
+
+            { domain: 'tone', value: 'conversational', source: 'observation', confidence: 0.65 }
+          end
+
+          def derive_format(signals)
+            unique_channels = signals.map { |s| s[:channel] }.uniq
+            return nil unless unique_channels.size >= 3
+
+            { domain: 'format', value: 'adaptive', source: 'observation', confidence: 0.55 }
+          end
         end
       end
     end

--- a/lib/legion/extensions/mesh/version.rb
+++ b/lib/legion/extensions/mesh/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Mesh
-      VERSION = '0.4.3'
+      VERSION = '0.4.4'
     end
   end
 end

--- a/spec/legion/extensions/mesh/helpers/preference_profile_spec.rb
+++ b/spec/legion/extensions/mesh/helpers/preference_profile_spec.rb
@@ -191,6 +191,81 @@ RSpec.describe Legion::Extensions::Mesh::Helpers::PreferenceProfile do
     end
   end
 
+  describe '.update_from_observation' do
+    before { described_class.clear_observations }
+
+    let(:cli_signal)   { { content_type: :text, channel: :cli, direct_address: false } }
+    let(:chat_signal)  { { content_type: :text, channel: :chat, direct_address: true } }
+    let(:mixed_signal) { { content_type: :text, channel: :api, direct_address: false } }
+
+    it 'returns { updated: true } on each call' do
+      result = described_class.update_from_observation(owner_id: 'user-obs', signals: cli_signal)
+      expect(result).to eq({ updated: true })
+    end
+
+    it 'accumulates signals per owner_id' do
+      5.times { described_class.update_from_observation(owner_id: 'user-obs', signals: cli_signal) }
+      counts = described_class.observation_counts
+      expect(counts['user-obs']).to eq(5)
+    end
+
+    it 'does not infer preferences before threshold (20)' do
+      19.times { described_class.update_from_observation(owner_id: 'user-obs', signals: cli_signal) }
+      inferred = described_class.inferred_preferences('user-obs')
+      expect(inferred).to be_empty
+    end
+
+    it 'derives :concise verbosity for CLI-heavy usage after threshold' do
+      20.times { described_class.update_from_observation(owner_id: 'user-cli', signals: cli_signal) }
+      inferred = described_class.inferred_preferences('user-cli')
+      verbosity = inferred.find { |p| p[:domain] == 'verbosity' }
+      expect(verbosity).not_to be_nil
+      expect(verbosity[:value]).to eq('concise')
+      expect(verbosity[:source]).to eq('observation')
+    end
+
+    it 'derives :conversational tone for high direct_address ratio after threshold' do
+      20.times { described_class.update_from_observation(owner_id: 'user-da', signals: chat_signal) }
+      inferred = described_class.inferred_preferences('user-da')
+      tone = inferred.find { |p| p[:domain] == 'tone' }
+      expect(tone).not_to be_nil
+      expect(tone[:value]).to eq('conversational')
+      expect(tone[:source]).to eq('observation')
+    end
+
+    it 'derives :adaptive format for mixed channel usage after threshold' do
+      channels = %i[cli api chat rest]
+      20.times.with_index do |i, _|
+        ch = channels[i % channels.length]
+        described_class.update_from_observation(
+          owner_id: 'user-mix',
+          signals:  { content_type: :text, channel: ch, direct_address: false }
+        )
+      end
+      inferred = described_class.inferred_preferences('user-mix')
+      format = inferred.find { |p| p[:domain] == 'format' }
+      expect(format).not_to be_nil
+      expect(format[:value]).to eq('adaptive')
+      expect(format[:source]).to eq('observation')
+    end
+
+    it 'keeps separate observation counts per owner_id' do
+      3.times { described_class.update_from_observation(owner_id: 'user-a', signals: cli_signal) }
+      7.times { described_class.update_from_observation(owner_id: 'user-b', signals: cli_signal) }
+      counts = described_class.observation_counts
+      expect(counts['user-a']).to eq(3)
+      expect(counts['user-b']).to eq(7)
+    end
+
+    it 'calls store_preference for each inferred preference after threshold' do
+      allow(described_class).to receive(:store_preference).and_call_original
+      20.times { described_class.update_from_observation(owner_id: 'user-store', signals: cli_signal) }
+      expect(described_class).to have_received(:store_preference).with(
+        hash_including(owner_id: 'user-store', source: 'observation')
+      ).at_least(:once)
+    end
+  end
+
   describe '.preference_instructions' do
     it 'generates natural language prompt instructions from profile' do
       profile = {


### PR DESCRIPTION
## Summary
- `PreferenceProfile.update_from_observation` accumulates interaction signals
- After 20 observations, derives preferences (verbosity, tone, format)
- 295 specs, 0 failures

## Test plan
- [x] Signals accumulated per owner_id
- [x] Preferences derived after threshold
- [x] CLI-heavy -> concise, direct_address -> conversational, mixed -> adaptive
- [x] Full suite regression-free